### PR TITLE
Check if location was not sent in redirect header

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,11 @@ function direct(subquest, maxRedirects) {
         res.url = opts.uri;
         if (isRedirect(res.statusCode)) {
           remainingRedirects--;
+
+          if (res.headers.location === undefined) {
+            return rs.emit('error', new Error('The response was redirected but received an empty Location'));
+          } 
+          
           rs.emit('redirect', res);
           opts.uri = res.headers.location;
           return doRequest();


### PR DESCRIPTION
It is not usual, but I've found a couple of servers that ocassionally send a redirect response without location header field. I added a verification so an error is emited instead of throwing an unhandled exception.
