### PR TITLE
Add 303 status code to isRedirect

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,5 +64,5 @@ function direct(subquest, maxRedirects) {
 }
 
 function isRedirect(statusCode) {
-  return statusCode === 301 || statusCode === 302 || statusCode === 307 || statusCode === 308;
+  return statusCode === 301 || statusCode === 302 || statusCode === 303 || statusCode === 307 || statusCode === 308;
 }


### PR DESCRIPTION
I ran into this problem when trying to download bird sounds from xeno-canto. They use HTTP status code 303 to indicate redirection, which – according to https://en.wikipedia.org/wiki/HTTP_303 – seems legit.
